### PR TITLE
Create basic src modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gihary-mvp",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -1,0 +1,10 @@
+/**
+ * Firestore persistence
+ */
+
+async function saveTasks(tasks) {
+  // TODO: implement Firestore write
+  return Promise.resolve();
+}
+
+module.exports = { saveTasks };

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1,0 +1,19 @@
+/**
+ * Gmail integration module
+ * Provides authentication and message fetching placeholders
+ */
+
+async function authenticate() {
+  // TODO: implement OAuth2 flow
+  return Promise.resolve('gmail-auth-token');
+}
+
+async function fetchMessages(authToken) {
+  // TODO: use Gmail API to fetch messages
+  return Promise.resolve([]);
+}
+
+module.exports = {
+  authenticate,
+  fetchMessages
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,24 @@
+const gmail = require('./gmail');
+const llm = require('./llm');
+const firestore = require('./firestore');
+
+async function authenticate() {
+  return gmail.authenticate();
+}
+
+async function processEmails() {
+  const authToken = await gmail.authenticate();
+  const messages = await gmail.fetchMessages(authToken);
+  const tasks = [];
+  for (const msg of messages) {
+    const extracted = await llm.extractTasksFromEmail(msg);
+    tasks.push(...extracted);
+  }
+  await firestore.saveTasks(tasks);
+  return tasks;
+}
+
+module.exports = {
+  authenticate,
+  processEmails
+};

--- a/src/llm.js
+++ b/src/llm.js
@@ -1,0 +1,10 @@
+/**
+ * LLM-based task extraction
+ */
+
+async function extractTasksFromEmail(content) {
+  // TODO: implement LLM call to parse tasks
+  return Promise.resolve([]);
+}
+
+module.exports = { extractTasksFromEmail };


### PR DESCRIPTION
## Summary
- add src directory with entry point `src/index.js`
- scaffold Gmail, LLM, and Firestore modules
- expose authentication and email processing functions
- point `main` to `src/index.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852939bc72083268620bc902d325a65