### PR TITLE
Fix Gatsby comment in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ dist
 
 # Gatsby files
 .cache/
-# Comment in the public line in if your project uses Gatsby and not Next.js
+# Uncomment the next line if your project uses Gatsby instead of Next.js
 # https://nextjs.org/blog/next-9-1#public-directory-support
 # public
 


### PR DESCRIPTION
## Summary
- clarify when to uncomment `public/` by updating Gatsby comment in `.gitignore`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685299c545dc8326b1e61596ddf9b48f