### PR TITLE
Update README with Node 18 test note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository outlines a minimal setup for the **Gihary MVP**, an application 
 
 1. **Node.js**
    - Install Node.js version **18 or higher**.
+   - The project uses Node's built-in test runner (`node --test`), so Node 18+ is required.
    - Clone this repository and install dependencies:
      ```bash
      npm install


### PR DESCRIPTION
## Summary
- clarify Node version requirement
- note that the built-in test runner `node --test` requires Node 18+

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685299cde7048326bf0f3e0b2dcb72b3