### PR TITLE
Remove invalid Google AI Edge deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ This README provides a high-level overview. Implementations of Gmail access, tas
 1. **Node.js**
    - Install Node.js version **18 or higher**. The project requires Node
      18 or newer as defined in `package.json`.
-   - Clone this repository and install dependencies:
+   - Clone this repository. The project currently has no external
+     dependencies because the Google AI Edge packages referenced in the
+     code have not yet been published.
+   - Run `npm install` anyway so that future dependencies can be installed
+     without changing these steps:
      ```bash
      npm install
      ```
@@ -51,4 +55,7 @@ This README provides a high-level overview. Implementations of Gmail access, tas
 npm install      # install dependencies
 node src/index.js    # run the project
 ```
+
+When the Google AI Edge packages become publicly available, add them to
+`package.json` and run `npm install` again to install the libraries.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "gihary-mvp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gihary-mvp",
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,5 @@
   "engines": {
     "node": ">=18"
   },
-  "dependencies": {
-    "@google-ai-edge/litert-api": "^1.0.0",
-    "@google-ai-edge/ai-edge-apis": "^1.0.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
## Summary
- remove `@google-ai-edge` packages from dependencies
- clarify installation steps for missing AI Edge libraries
- generate package lock for empty dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529e17954c8326b66766c863d65c08