### PR TITLE
Fix Node test module type

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
-import test from 'node:test';
-import assert from 'node:assert';
-import { spawnSync } from 'node:child_process';
-import path from 'node:path';
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
 
 // Ensure that running the main module prints "Hello World"
 test('prints Hello World from main module', () => {


### PR DESCRIPTION
## Summary
- switch the test runner entrypoint to CommonJS to avoid module warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529f02f8708326bf87cc0b23ab6b97