### PR TITLE
Add placeholder modules for Gmail, Firestore, and agent orchestration

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -1,0 +1,12 @@
+// Placeholder module for agent orchestration
+// This will coordinate Gmail, task extraction, and storage
+
+/**
+ * Orchestrate processing of emails to tasks.
+ * @returns {Promise<void>}
+ */
+async function orchestrate() {
+  // Not yet implemented
+}
+
+module.exports = { orchestrate };

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -1,0 +1,24 @@
+// Placeholder module for Firestore storage
+// Replace with actual Firestore implementation
+
+/**
+ * Save a task for a user.
+ * @param {string} userId
+ * @param {object} task
+ * @returns {Promise<void>}
+ */
+async function saveTask(userId, task) {
+  // Not yet implemented
+}
+
+/**
+ * List tasks for a user.
+ * @param {string} userId
+ * @returns {Promise<Array>}
+ */
+async function listTasks(userId) {
+  // Not yet implemented
+  return [];
+}
+
+module.exports = { saveTask, listTasks };

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1,0 +1,13 @@
+// Placeholder module for Gmail integration
+// Future implementations should use the Gmail API here
+
+/**
+ * Fetch unread emails for the application user.
+ * @returns {Promise<Array>} Resolves with an array of email objects.
+ */
+async function fetchUnreadEmails() {
+  // Not yet implemented
+  return [];
+}
+
+module.exports = { fetchUnreadEmails };


### PR DESCRIPTION
## Summary
- add gmail integration placeholder module
- add firestore storage placeholder module
- add agent orchestration placeholder module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529fc325608326860364b46d433b7b