### PR TITLE
Add dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ This README provides a high-level overview. Implementations of Gmail access, tas
    - Clone this repository. The project currently has no external
      dependencies because the Google AI Edge packages referenced in the
      code have not yet been published.
-   - Run `npm install` anyway so that future dependencies can be installed
-     without changing these steps:
-     ```bash
-     npm install
-     ```
+  - Run `npm install` anyway so that future dependencies can be installed
+    without changing these steps:
+    ```bash
+    npm install
+    ```
+  - Copy `.env.sample` to `.env` and fill in your environment variables. The
+    project uses [dotenv](https://www.npmjs.com/package/dotenv) to load
+    this file automatically.
 
 2. **Gmail OAuth configuration**
    - Create OAuth credentials in the [Google Cloud Console](https://console.cloud.google.com/).
@@ -44,7 +47,8 @@ This README provides a high-level overview. Implementations of Gmail access, tas
      ```
 
 4. **Running the project**
-   - Ensure all environment variables above are configured.
+   - Ensure all environment variables above are configured. If you created a
+     `.env` file, they will be loaded automatically when the app starts.
    - Start the application with Node.js:
      ```bash
      node src/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,23 @@
       "name": "gihary-mvp",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.5.0"
+      },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,7 @@
   "engines": {
     "node": ">=18"
   },
-  "dependencies": {}
+  "dependencies": {
+    "dotenv": "^16.5.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,4 @@
+// Load environment variables from a .env file if present
+require('dotenv').config();
+
 console.log('Hello World');


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file in the main entry point
- install the `dotenv` runtime dependency
- document `.env` setup and loading in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a55b514883268203badbacf105dd