### PR TITLE
Improve Gmail env var validation

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -23,8 +23,15 @@ function getOAuth2Client() {
     GMAIL_REFRESH_TOKEN,
   } = process.env;
 
-  if (!GMAIL_CLIENT_ID || !GMAIL_CLIENT_SECRET || !GMAIL_REDIRECT_URI) {
-    throw new Error('Missing Gmail OAuth environment variables');
+  const missing = [];
+  if (!GMAIL_CLIENT_ID) missing.push('GMAIL_CLIENT_ID');
+  if (!GMAIL_CLIENT_SECRET) missing.push('GMAIL_CLIENT_SECRET');
+  if (!GMAIL_REDIRECT_URI) missing.push('GMAIL_REDIRECT_URI');
+  if (missing.length > 0) {
+    const plural = missing.length > 1 ? 'variables' : 'variable';
+    throw new Error(
+      `Missing Gmail OAuth ${plural}: ${missing.join(', ')}`,
+    );
   }
 
   const oauth2Client = new google.auth.OAuth2(

--- a/test/gmail.test.js
+++ b/test/gmail.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { fetchUnreadEmails } = require('../src/gmail');
+const { fetchUnreadEmails, getOAuth2Client } = require('../src/gmail');
 
 // Mock Gmail API methods
 function createStubGmail({ listError } = {}) {
@@ -16,6 +16,34 @@ function createStubGmail({ listError } = {}) {
     },
   };
 }
+
+test('getOAuth2Client returns client when vars are set', () => {
+  process.env.GMAIL_CLIENT_ID = 'id';
+  process.env.GMAIL_CLIENT_SECRET = 'secret';
+  process.env.GMAIL_REDIRECT_URI = 'uri';
+
+  const client = getOAuth2Client();
+  assert.ok(client);
+});
+
+test('getOAuth2Client errors for missing GMAIL_CLIENT_ID', () => {
+  delete process.env.GMAIL_CLIENT_ID;
+  process.env.GMAIL_CLIENT_SECRET = 'secret';
+  process.env.GMAIL_REDIRECT_URI = 'uri';
+
+  assert.throws(() => getOAuth2Client(), /GMAIL_CLIENT_ID/);
+});
+
+test('getOAuth2Client errors for multiple missing vars', () => {
+  delete process.env.GMAIL_CLIENT_ID;
+  delete process.env.GMAIL_CLIENT_SECRET;
+  process.env.GMAIL_REDIRECT_URI = 'uri';
+
+  assert.throws(
+    () => getOAuth2Client(),
+    /GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET/
+  );
+});
 
 test('fetchUnreadEmails returns messages', async () => {
   const emails = await fetchUnreadEmails(createStubGmail());


### PR DESCRIPTION
## Summary
- validate each Gmail OAuth environment variable individually
- show which variables are missing in the error
- add tests for the new validation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852b0bb1c0483268473ad8a8fa4d393