### PR TITLE
Add logger module for Firestore events

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,28 @@
+const { getFirestore } = require('./firestore');
+
+/**
+ * Log an event for a user in Firestore under logs/{userId}/events.
+ *
+ * @param {string} userId - User identifier.
+ * @param {string} action - Event action name.
+ * @param {object} [metadata] - Additional event data.
+ * @returns {Promise<object>} The stored payload.
+ */
+async function logEvent(userId, action, metadata = {}) {
+  if (!userId) throw new Error('userId is required');
+  if (!action) throw new Error('action is required');
+  const db = getFirestore();
+  const payload = {
+    action,
+    metadata,
+    timestamp: Date.now(),
+  };
+  await db
+    .collection('logs')
+    .doc(userId)
+    .collection('events')
+    .add(payload);
+  return payload;
+}
+
+module.exports = { logEvent };

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+function createFakeFirestore() {
+  const store = {};
+  return {
+    store,
+    collection() {
+      return {
+        doc(userId) {
+          return {
+            collection() {
+              return {
+                async add(data) {
+                  store[userId] = store[userId] || [];
+                  store[userId].push(data);
+                  return { id: String(store[userId].length) };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('logEvent stores action, metadata and timestamp', async () => {
+  const fakeDb = createFakeFirestore();
+  process.env.FIREBASE_ADMIN_KEY_PATH = path.resolve(__dirname, 'fixtures', 'serviceAccount.json');
+  delete require.cache[require.resolve('../src/firestore')];
+  const { setFirestore } = require('../src/firestore');
+  setFirestore(fakeDb);
+
+  delete require.cache[require.resolve('../src/logger')];
+  const { logEvent } = require('../src/logger');
+
+  await logEvent('user1', 'test-action', { foo: 'bar' });
+
+  const events = fakeDb.store['user1'];
+  assert.strictEqual(events.length, 1);
+  const event = events[0];
+  assert.strictEqual(event.action, 'test-action');
+  assert.deepStrictEqual(event.metadata, { foo: 'bar' });
+  assert.ok(event.timestamp);
+});


### PR DESCRIPTION
## Summary
- add `src/logger.js` for recording events to `logs/{userId}/events` in Firestore
- test logging with in-memory Firestore stub

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ba8e5abc832683d46f55bda73b8c