### PR TITLE
Implement profile rollback command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "node --test",
     "start": "node src/index.js",
-    "testing": "npm test"
+    "testing": "npm test",
+    "rollback": "node src/cli/rollback-cli.js"
   },
   "keywords": [],
   "author": "Gihary",

--- a/src/cli/rollback-cli.js
+++ b/src/cli/rollback-cli.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+const { rollbackClientProfile } = require('../rollback');
+
+async function main() {
+  const arg = process.argv.find((a) => a.startsWith('--email='));
+  if (!arg) {
+    console.error('Usage: npm run rollback -- --email=<address>');
+    process.exit(1);
+  }
+  const email = arg.split('=')[1];
+  try {
+    await rollbackClientProfile(email);
+    console.log('Profile restored from backup');
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/src/rollback.js
+++ b/src/rollback.js
@@ -1,0 +1,33 @@
+const { getFirestore } = require('./firestore');
+
+/**
+ * Restore the latest profile backup for a client.
+ * Backup document must exist at clients/{email}/backup/profile.
+ *
+ * @param {string} email - Client email identifier.
+ * @returns {Promise<object>} Restored profile data.
+ */
+async function rollbackClientProfile(email) {
+  if (!email) throw new Error('email is required');
+  const db = getFirestore();
+
+  const backupRef = db
+    .collection('clients')
+    .doc(email)
+    .collection('backup')
+    .doc('profile');
+
+  const snap = await backupRef.get();
+  if (!snap.exists) throw new Error('No backup found');
+  const data = snap.data();
+
+  const profileRef = db
+    .collection('clients')
+    .doc(email)
+    .collection('profile')
+    .doc('profile');
+  await profileRef.set(data);
+  return data;
+}
+
+module.exports = { rollbackClientProfile };

--- a/test/rollback.test.js
+++ b/test/rollback.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+function createFakeFirestore(backupData = {}) {
+  const store = {};
+  if (backupData.email) {
+    store[backupData.email] = {
+      backup: backupData.data,
+      profile: null,
+    };
+  }
+  return {
+    store,
+    collection() {
+      return {
+        doc(email) {
+          store[email] = store[email] || { backup: null, profile: null };
+          return {
+            collection(name) {
+              if (name === 'backup') {
+                return {
+                  doc() {
+                    return {
+                      async get() {
+                        const data = store[email].backup;
+                        if (!data) return { exists: false };
+                        return { exists: true, data: () => data };
+                      },
+                    };
+                  },
+                };
+              }
+              if (name === 'profile') {
+                return {
+                  doc() {
+                    return {
+                      async set(data) {
+                        store[email].profile = data;
+                      },
+                    };
+                  },
+                };
+              }
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('rollbackClientProfile copies backup to active profile', async () => {
+  const fakeDb = createFakeFirestore({
+    email: 'user@example.com',
+    data: { fullName: 'Backup User' },
+  });
+  process.env.FIREBASE_ADMIN_KEY_PATH = path.resolve(__dirname, 'fixtures', 'serviceAccount.json');
+  delete require.cache[require.resolve('../src/firestore')];
+  const { setFirestore } = require('../src/firestore');
+  setFirestore(fakeDb);
+  const { rollbackClientProfile } = require('../src/rollback');
+  await rollbackClientProfile('user@example.com');
+  assert.deepStrictEqual(fakeDb.store['user@example.com'].profile, { fullName: 'Backup User' });
+});
+


### PR DESCRIPTION
## Summary
- add rollbackClientProfile() to restore backed up CRM data
- expose CLI under `npm run rollback`
- test rollback helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852bb665f7083269275e9a1148c15e7