### PR TITLE
Add saveToCore helper

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,42 @@
+const { getFirestore } = require('./firestore');
+
+/**
+ * Save data to the core memory collection.
+ *
+ * Data is stored under `core_memory/{id}/info`. The `id` comes from
+ * `data.email` if present, otherwise any available identifier in `data.id`.
+ * Existing documents are updated with merge=true to retain previous fields.
+ *
+ * @param {object} data - Data to persist.
+ * @returns {Promise<object>} The stored payload.
+ */
+async function saveToCore(data) {
+  if (!data) throw new Error('data is required');
+  const id = data.email || data.id;
+  if (!id) throw new Error('identifier required');
+
+  const db = getFirestore();
+  const docRef = db
+    .collection('core_memory')
+    .doc(id)
+    .collection('info')
+    .doc('info');
+
+  const payload = {
+    nome: data.nome,
+    ultimi_intenti: data.ultimi_intenti,
+    parole_chiave: data.parole_chiave,
+    priorità_media: data.priorità_media,
+    ultimo_aggiornamento: data.ultimo_aggiornamento || Date.now(),
+  };
+
+  const snap = await docRef.get();
+  if (snap.exists) {
+    await docRef.set(payload, { merge: true });
+  } else {
+    await docRef.set(payload);
+  }
+  return payload;
+}
+
+module.exports = { saveToCore };

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+function createFakeFirestore() {
+  const store = {};
+  return {
+    store,
+    collection(name) {
+      if (name !== 'core_memory') throw new Error('Unexpected collection');
+      return {
+        doc(id) {
+          store[id] = store[id] || { info: null };
+          return {
+            collection(col) {
+              if (col !== 'info') throw new Error('Unexpected subcollection');
+              return {
+                doc() {
+                  return {
+                    async get() {
+                      const data = store[id].info;
+                      if (!data) return { exists: false };
+                      return { exists: true, data: () => data };
+                    },
+                async set(data, opts = {}) {
+                      if (opts.merge && store[id].info) {
+                        const merged = { ...store[id].info };
+                        for (const [k, v] of Object.entries(data)) {
+                          if (v !== undefined) merged[k] = v;
+                        }
+                        store[id].info = merged;
+                      } else {
+                        store[id].info = data;
+                      }
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('saveToCore stores new document', async () => {
+  const fakeDb = createFakeFirestore();
+  process.env.FIREBASE_ADMIN_KEY_PATH = path.resolve(__dirname, 'fixtures', 'serviceAccount.json');
+  delete require.cache[require.resolve('../src/firestore')];
+  const { setFirestore } = require('../src/firestore');
+  setFirestore(fakeDb);
+  delete require.cache[require.resolve('../src/core')];
+  const { saveToCore } = require('../src/core');
+  await saveToCore({ email: 'user@example.com', nome: 'User', ultimi_intenti: [] });
+  const stored = fakeDb.store['user@example.com'].info;
+  assert.strictEqual(stored.nome, 'User');
+  assert.ok(Array.isArray(stored.ultimi_intenti));
+});
+
+test('saveToCore merges existing document', async () => {
+  const fakeDb = createFakeFirestore();
+  fakeDb.store['user@example.com'] = { info: { nome: 'Old', parole_chiave: ['a'], extra: 1 } };
+  process.env.FIREBASE_ADMIN_KEY_PATH = path.resolve(__dirname, 'fixtures', 'serviceAccount.json');
+  delete require.cache[require.resolve('../src/firestore')];
+  const { setFirestore } = require('../src/firestore');
+  setFirestore(fakeDb);
+  delete require.cache[require.resolve('../src/core')];
+  const { saveToCore } = require('../src/core');
+  await saveToCore({ email: 'user@example.com', nome: 'New', priorità_media: 5 });
+  const stored = fakeDb.store['user@example.com'].info;
+  assert.strictEqual(stored.nome, 'New');
+  assert.deepStrictEqual(stored.parole_chiave, ['a']);
+  assert.strictEqual(stored.priorità_media, 5);
+  assert.strictEqual(stored.extra, 1);
+});


### PR DESCRIPTION
## Summary
- add `saveToCore` Firestore helper to persist core memory data
- cover save and merge behavior with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e8163f088326b49bf0050d107d9a